### PR TITLE
Manpages v2

### DIFF
--- a/man/man1/m2h.sh
+++ b/man/man1/m2h.sh
@@ -1,0 +1,7 @@
+
+for file in *.1
+do
+	manpage=${file%.1*}
+	cat ${manpage}".1" | groff -mandoc -Thtml > ${manpage}".html"
+done
+

--- a/man/man1/m2local.sh
+++ b/man/man1/m2local.sh
@@ -1,0 +1,5 @@
+for file in *.1
+do
+	sudo cp $file /usr/local/man/man1
+done
+

--- a/man/man1/makefile
+++ b/man/man1/makefile
@@ -1,0 +1,13 @@
+usage:
+	
+	@echo "Usage:"
+	@echo "	make install-html, generate html in current dir"
+	@echo "	make install-local, copy manpages to /usr/local/man/man1"
+
+.PHONY: clean install-html install-local
+
+install-html: 
+	 @./m2h.sh
+
+install-local:
+	@./m2local.sh

--- a/man/man1/vsw-attest.1
+++ b/man/man1/vsw-attest.1
@@ -1,0 +1,111 @@
+\" This template provides an example of how to generate a Linux man" pages for a new command
+\"	NAME Section goes here
+\"
+.TH VSW-ATTEST "1" "September 2020" "C. T. Al-Hakim" "Verifiable Software - VSW"
+.SH NAME  
+attest \- Attest SW package in the VS repo
+\"	SYNOPSIS Section goes here
+\"
+.SH SYNOPSIS  
+\fBvsw attest\fR
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+\"
+\"	DESCRIPTION Section goes here
+\"
+.SH DESCRIPTION  
+\" Add detailed description here
+.PP
+\fBvsw attest\fR - attest is used to certify SW packages in the VS software Repo by the Repo Holder
+.PP
+Mandatory arguments go here...
+.TP
+\fB\-u\fR, \fB\-\-user [DID]\fR 
+Holder DID (Decentralized ID)
+.TP
+\fB\-l\fR, \fB\-\-list\fR
+list all attestations
+.TP
+\fB\-r\fR, \fB\-\-revoke\fR [Credentials]
+Revoke attestation(s)
+.TP
+\fB\-p\fR, \fB\-\-package\fR [PackageName] 
+Name of Package being certified
+.TP
+\fB\-f\fR, \fB\-\-file\fR FileName
+send output to FileName
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+print help menu
+.SS "Exit status:"
+.TP
+0
+if OK,
+.TP
+1
+if minor problems (e.g., cannot access subdirectory),
+.TP
+2
+if serious trouble (e.g., cannot access command\-line argument).
+
+\"
+\"	FILES Section goes here
+\"
+.SH FILES  
+.TP  
+.I  /etc/attest.conf  
+.TP  
+.I  /usr/bin/attest    
+.TP  
+.I  Schema
+\"
+\"	EXAMPLES Section goes here
+\"
+.SH EXAMPLES  
+.TP  
+\fBvsw_attest\~--type\fR\~ edu\fB\~ --issuer\fR\~ issuer_credentials
+(Run attest with my_arg2 value for team2 value)      
+\"
+\"	DIAGNOSTICS Section goes here
+\"
+.SH DIAGNOSTICS  
+.PP
+The activity performed using this utility is logged in the file \fB/var/log/attest\fR      
+\"
+\"	REPORTING BUGS Section goes here
+\"
+.SH "REPORTING BUGS"
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+.br
+Report ls translation bugs to <http://translationproject.org/team/>
+\"
+\"	AUTHOR Section goes here
+\"
+.SH AUTHOR
+Written by Name1 and Name2, ...
+\"
+\"	COPYRIGHT Section goes here
+\"
+.SH COPYRIGHT
+Copyright \(co 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+\"
+\"	CREDITS Section goes here
+\"
+.SH CREDITS  
+.PP	
+This man page was created only for demonstration purpose by Chaker Al-Hakim on 09/10/2020
+\"
+\"	SEE ALSO Section goes here
+\"
+.SH SEE ALSO  
+.br
+vsw register(1)  
+.br 
+vsw list(1)  
+.br 
+vsw attest(1)  
+.br 
+vsw publish(1)  
+.br 
+vsw verify(1)  
+.br 

--- a/man/man1/vsw-audit.1
+++ b/man/man1/vsw-audit.1
@@ -1,0 +1,109 @@
+\" This template provides an example of how to generate a Linux man" pages for a new command
+\"	NAME Section goes here
+\"
+.TH VSW-AUDIT "1" "September 2020" "C. T. Al-Hakim" "Verifiable Software"
+.SH NAME  
+vsm audit \- Audit SW package in the VS repo
+\"	SYNOPSIS Section goes here
+\"
+.SH SYNOPSIS  
+\fBvsm audit\fR
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+\"
+\"	DESCRIPTION Section goes here
+\"
+.SH DESCRIPTION  
+\" Add detailed description here
+.PP
+\fBvsm audit\fR - vsm audit is used to audit SW packages in the VS software Rep.
+it will scan the project for vulnerabilities and will either attempt to automatically fix any vulnerable dependenies or it will generate a report listing all the vulnerabilites
+.PP
+Mandatory arguments go here...
+.TP
+\fB\-u\fR, \fB\-\-user [DID]\fR 
+Audit DID (Decentralized ID)
+.TP
+\fB\-p\fR, \fB\-\-package\fR [PackageName] 
+Audit a specific Package
+.TP
+\fB\-l\fR, \fB\-\-list\fR 
+list all packages in the Repo
+.TP
+\fB\-x\fR, \fB\-\-fix\fR 
+ run the audit and fix all vulnerablities
+.TP
+\fB\-f\fR, \fB\-\-file\fR FileName
+send output to FileName
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+print help menu
+.SS "Exit status:"
+.TP
+0
+if OK,
+.TP
+1
+if minor problems (e.g., cannot access subdirectory),
+.TP
+2
+if serious trouble (e.g., cannot access command\-line argument).
+
+\"
+\"	FILES Section goes here
+\"
+.SH FILES  
+.TP  
+.I  /etc/vsm_audit.conf  
+.TP  
+.I  /usr/bin/vsm_audit    
+\"
+\"	EXAMPLES Section goes here
+\"
+.SH EXAMPLES  
+.TP  
+\fBvsm audit\~--p\fR\~ PackageName\fB\~ --fix\fR\
+\"
+\"	DIAGNOSTICS Section goes here
+\"
+.SH DIAGNOSTICS  
+.PP
+The activity performed using this utility is logged in the file \fB/var/log/vsm_audit\fR      
+\"
+\"	REPORTING BUGS Section goes here
+\"
+.SH "REPORTING BUGS"
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+.br
+Report ls translation bugs to <http://translationproject.org/team/>
+\"
+\"	AUTHOR Section goes here
+\"
+.SH AUTHOR
+Written by Name1 and Name2, ...
+\"
+\"	COPYRIGHT Section goes here
+\"
+.SH COPYRIGHT
+Copyright \(co 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+\"
+\"	CREDITS Section goes here
+\"
+.SH CREDITS  
+.PP	
+This man page was created only for demonstration purpose by Chaker Al-Hakim on 09/10/2020
+\"
+\"	SEE ALSO Section goes here
+\"
+.SH SEE ALSO  
+.br
+vsm register(1)  
+.br 
+vsm list(1)  
+.br 
+vsm certify(1)  
+.br 
+vsm publish(1)  
+.br 
+vsm verify(1)  
+.br 

--- a/man/man1/vsw-list.1
+++ b/man/man1/vsw-list.1
@@ -1,0 +1,107 @@
+\" This template provides an example of how to generate a Linux man" pages for a new command
+\"	NAME Section goes here
+\"
+.TH VSW-LIST "1" "September 2020" "C. T. Al-Hakim" "Verifiable Software"
+.SH NAME  
+vsw list \- vsw list SW package in the VS repo
+\"	SYNOPSIS Section goes here
+\"
+.SH SYNOPSIS  
+\fBvsw list\fR
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+\"
+\"	DESCRIPTION Section goes here
+\"
+.SH DESCRIPTION  
+\" Add detailed description here
+.PP
+\fBvsw list\fR - vsw list is used to list all versions of software packages in the VS software Depo as well as their dependencies in a tree-like format.
+it will also print missing and invalid packages
+.PP
+Mandatory arguments go here...
+.TP
+\fB\-u\fR, \fB\-\-user [DID]\fR 
+user DID (Decentralized ID)
+.TP
+\fB\-p\fR, \fB\-\-package\fR [PackageName] 
+Name of Package being list
+.TP
+\fB\-a\fR, \fB\-\-all\fR [PackageName] 
+List all packages in the Depo
+.TP
+\fB\-f\fR, \fB\-\-file\fR FileName
+send output to FileName
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+print help menu
+.SS "Exit status:"
+.TP
+0
+if OK,
+.TP
+1
+if minor problems (e.g., cannot access subdirectory),
+.TP
+2
+if serious trouble (e.g., cannot access command\-line argument).
+
+\"
+\"	FILES Section goes here
+\"
+.SH FILES  
+.TP  
+.I  /etc/vsw_list.conf  
+.TP  
+.I  /usr/bin/vsw_list    
+\"
+\"	EXAMPLES Section goes here
+\"
+.SH EXAMPLES  
+.TP  
+\fBvsw list\~--type\fR\~ edu\fB\~ --issuer\fR\~ issuer_credentials
+(Run vsw list with my_arg2 value for team2 value)      
+\"
+\"	DIAGNOSTICS Section goes here
+\"
+.SH DIAGNOSTICS  
+.PP
+The activity performed using this utility is logged in the file \fB/var/log/vsw_list\fR      
+\"
+\"	REPORTING BUGS Section goes here
+\"
+.SH "REPORTING BUGS"
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+.br
+Report ls translation bugs to <http://translationproject.org/team/>
+\"
+\"	AUTHOR Section goes here
+\"
+.SH AUTHOR
+Written by Name1 and Name2, ...
+\"
+\"	COPYRIGHT Section goes here
+\"
+.SH COPYRIGHT
+Copyright \(co 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+\"
+\"	CREDITS Section goes here
+\"
+.SH CREDITS  
+.PP	
+This man page was created only for demonstration purpose by Chaker Al-Hakim on 09/10/2020
+\"
+\"	SEE ALSO Section goes here
+\"
+.SH SEE ALSO  
+.br
+vsw register(1)  
+.br 
+vsw list(1)  
+.br 
+vsw certify(1)  
+.br 
+vsw publish(1)  
+.br 
+vsw verify(1)  
+.br 

--- a/man/man1/vsw-publish.1
+++ b/man/man1/vsw-publish.1
@@ -1,0 +1,109 @@
+\" This template provides an example of how to generate a Linux man" pages for a new command
+\"	NAME Section goes here
+\"
+.TH VSW-PUBLISH "1" "September 2020" "C. T. Al-Hakim" "Verifiable Software"
+.SH NAME  
+vsw-publish \- Publish SW package to the VS repo
+\"	SYNOPSIS Section goes here
+\"
+.SH SYNOPSIS  
+\fBvsw publish\fR
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+\"
+\"	DESCRIPTION Section goes here
+\"
+.SH DESCRIPTION  
+\" Add detailed description here
+.PP
+\fBvsw publish\fR - is used to publish SW packages in the VS software Depo by 
+the Developer so it can be intalled by name. All files in the package are
+ included.
+.br
+ By default vsw publish should publish to the public SW Repo
+.PP
+Mandatory arguments go here...
+.TP
+\fB\-u\fR, \fB\-\-user [DID|Alias] - Optional\fR 
+Holder DID (Decentralized ID)
+.TP
+\fB\-p\fR, \fB\-\-package\fR [packageName] 
+Name of the Package
+.TP
+\fB\-d\fR, \fB\-\-dir\fR [DirName] 
+Name of Directory conataining the Package
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+print help menu
+.SS "Exit status:"
+.TP
+0
+if OK,
+.TP
+1
+if minor problems (e.g., cannot access subdirectory),
+.TP
+2
+if serious trouble (e.g., cannot access command\-line argument).
+
+\"
+\"	FILES Section goes here
+\"
+.SH FILES  
+.TP  
+.I  /etc/vsm_publish.conf  
+.TP  
+.I  /usr/bin/vsm_publish    
+.TP  
+.I  .config
+\"
+\"	EXAMPLES Section goes here
+\"
+.SH EXAMPLES  
+.TP  
+\fBvsw publish\~--type\fR\~ edu\fB\~ --issuer\fR\~ issuer_credentials
+(Run vsw publish with my_arg2 value for team2 value)      
+\"
+\"	DIAGNOSTICS Section goes here
+\"
+.SH DIAGNOSTICS  
+.PP
+The activity performed using this utility is logged in the file \fB/var/log/vsm_publish\fR      
+\"
+\"	REPORTING BUGS Section goes here
+\"
+.SH "REPORTING BUGS"
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+.br
+Report ls translation bugs to <http://translationproject.org/team/>
+\"
+\"	AUTHOR Section goes here
+\"
+.SH AUTHOR
+Written by Name1 and Name2, ...
+\"
+\"	COPYRIGHT Section goes here
+\"
+.SH COPYRIGHT
+Copyright \(co 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+\"
+\"	CREDITS Section goes here
+\"
+.SH CREDITS  
+.PP	
+This man page was created only for demonstration purpose by Chaker Al-Hakim on 09/10/2020
+\"
+\"	SEE ALSO Section goes here
+\"
+.SH SEE ALSO  
+.br
+vsw register(1)  
+.br 
+vsw list(1)  
+.br 
+vsw certify(1)  
+.br 
+vsw publish(1)  
+.br 
+vsw verify(1)  
+.br 

--- a/man/man1/vsw-register.1
+++ b/man/man1/vsw-register.1
@@ -1,0 +1,108 @@
+\" This template provides an example of how to generate a Linux man" pages for a new command
+\"	NAME Section goes here
+\"
+.TH VSW-REGISTER "1" "September 2020" "C. T. Al-Hakim" "Verifiable Software"
+.SH NAME  
+vsw register \- Register a new Developer's Credentials and grant access to Repo
+\"	SYNOPSIS Section goes here
+\"
+.SH SYNOPSIS  
+\fBvsw register\fR
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+\"
+\"	DESCRIPTION Section goes here
+\"
+.SH DESCRIPTION  
+\" Add detailed description here
+.PP
+\fBvsw register\fR - is used to register or verify the credentials
+of a new developer(Issuer) and to grant access and permissions to add software
+pakages to the Verifiabe Software repo. \fBvsw register\fR can also be used to 
+define the scope for the user as well
+.PP
+Mandatory arguments go here...
+.TP
+\fB\-a\fR, \fB\-\-adduser [alias]\fR 
+Developer DID (Decentralized ID)
+.TP
+\fB\-u\fR, \fB\-\-update [DID]\fR 
+other Issuer Credentials
+.TP
+\fB\-l\fR, \fB\-\-list [DID]\fR 
+Check if DID already exists
+.TP
+\fB\-s\fR, \fB\-\-scope [SCOPE] - for future use\fR 
+If specified the DID will be associated with the specified scope
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+print help menu
+.SS "Exit status:"
+.TP
+0
+if OK,
+.TP
+1
+if minor problems (e.g., cannot access subdirectory),
+.TP
+2
+if serious trouble (e.g., cannot access command\-line argument).
+
+\"
+\"	FILES Section goes here
+\"
+.SH FILES  
+.TP  
+.I  /etc/vsw_register.conf  
+.TP  
+.I  /usr/bin/vsw_register    
+\"
+\"	EXAMPLES Section goes here
+\"
+.SH EXAMPLES  
+.TP  
+\fBvsw register\~--adduser\fR\~ DID\fB\~--scope\fR CompanyA
+\"
+\"	DIAGNOSTICS Section goes here
+\"
+.SH DIAGNOSTICS  
+.PP
+The activity performed using this utility is logged in the file \fB/var/log/vsw_register\fR      
+\"
+\"	REPORTING BUGS Section goes here
+\"
+.SH "REPORTING BUGS"
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+.br
+Report ls translation bugs to <http://translationproject.org/team/>
+\"
+\"	AUTHOR Section goes here
+\"
+.SH AUTHOR
+Written by Name1 and Name2, ...
+\"
+\"	COPYRIGHT Section goes here
+\"
+.SH COPYRIGHT
+Copyright \(co 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+\"
+\"	CREDITS Section goes here
+\"
+.SH CREDITS  
+.PP	
+This man page was created .... 09/10/2020
+\"
+\"	SEE ALSO Section goes here
+\"
+.SH SEE ALSO  
+.br 
+vsw audit(1)  
+.br 
+vsw list(1)  
+.br 
+vsw certify(1)  
+.br 
+vsw publish(1)  
+.br 
+vsw verify(1)  
+.br 

--- a/man/man1/vsw-verify.1
+++ b/man/man1/vsw-verify.1
@@ -1,0 +1,103 @@
+\" This template provides an example of how to generate a Linux man" pages for a new command
+\"	NAME Section goes here
+\"
+.TH VSW-VERTIFY "1" "September 2020" "C. T. Al-Hakim" "Verifiable Software"
+.SH NAME  
+vsw verify \- Verify SW package in the VS repo
+\"	SYNOPSIS Section goes here
+\"
+.SH SYNOPSIS  
+\fBvsw verify\fR
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+\"
+\"	DESCRIPTION Section goes here
+\"
+.SH DESCRIPTION  
+\" Add detailed description here
+.PP
+\fBvsw verify\fR - vsw verify is used to verify SW packages in the VS software Depo by the Depo Holder
+.PP
+Mandatory arguments go here...
+.TP
+\fB\-u\fR, \fB\-\-user [DID]\fR - optional 
+Holder DID (Decentralized ID)
+.TP
+\fB\-p\fR, \fB\-\-package\fR [PackageName] 
+Name of Package being verify
+.TP
+\fB\-f\fR, \fB\-\-file\fR FileName
+send output to FileName
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+print help menu
+.SS "Exit status:"
+.TP
+0
+if OK,
+.TP
+1
+if minor problems (e.g., cannot access subdirectory),
+.TP
+2
+if serious trouble (e.g., cannot access command\-line argument).
+
+\"
+\"	FILES Section goes here
+\"
+.SH FILES  
+.TP  
+.I  /etc/vsw verify.conf  
+.TP  
+.I  /usr/bin/vsw verify    
+\"
+\"	EXAMPLES Section goes here
+\"
+.SH EXAMPLES  
+.TP  
+\fBvsw verify\~--type\fR\~ edu\fB\~ --issuer\fR\~ issuer_credentials
+(Run vsw verify with my_arg2 value for team2 value)      
+\"
+\"	DIAGNOSTICS Section goes here
+\"
+.SH DIAGNOSTICS  
+.PP
+The activity performed using this utility is logged in the file \fB/var/log/vsm_verify\fR      
+\"
+\"	REPORTING BUGS Section goes here
+\"
+.SH "REPORTING BUGS"
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+.br
+Report ls translation bugs to <http://translationproject.org/team/>
+\"
+\"	AUTHOR Section goes here
+\"
+.SH AUTHOR
+Written by Name1 and Name2, ...
+\"
+\"	COPYRIGHT Section goes here
+\"
+.SH COPYRIGHT
+Copyright \(co 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+\"
+\"	CREDITS Section goes here
+\"
+.SH CREDITS  
+.PP	
+This man page was created only for demonstration purpose by Chaker Al-Hakim on 09/10/2020
+\"
+\"	SEE ALSO Section goes here
+\"
+.SH SEE ALSO  
+.br
+vsw register(1)  
+.br 
+vsw list(1)  
+.br 
+vsw certify(1)  
+.br 
+vsw publish(1)  
+.br 
+vsw verify(1)  
+.br 


### PR DESCRIPTION
Made a change to store the manpages in plan text instead of .gz format
Added a makefile and options  to generate .html filesin local dir and/or to install the text manpages in /usr/local/man/man1 